### PR TITLE
Close button and nested components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `close` variant for buttons. #20
+
+### Changed
+
+- Use close button variant for `dismissible` alerts. #15
+
+### Fixed
+
+- Print code coverage as text by `composer test:coverage:generate`.
+
 ## 0.4 - 2025-02-11
 
 ### Added 

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "test:unit": "./tools/phpunit --testsuite Unit",
         "test:integration": "./tools/phpunit --testsuite Integration",
         "test:coverage": "XDEBUG_MODE=coverage ./tools/phpunit --coverage-text",
-        "test:coverage:generate": "XDEBUG_MODE=coverage ./tools/phpunit --coverage-html=./reports/phpunit/coverage"
+        "test:coverage:generate": "XDEBUG_MODE=coverage ./tools/phpunit --coverage-html=./reports/phpunit/coverage --coverage-text"
     },
     "extra": {
         "cotor": {

--- a/src/Twig/Component/Button.php
+++ b/src/Twig/Component/Button.php
@@ -16,13 +16,21 @@ final class Button implements VariantInterface
     public ButtonType $type;
     public ?string $label = null;
     public ?string $icon = null;
-    protected bool $isOutline = false;
+    private bool $isOutline = false;
+    private bool $isClose = false;
 
     public function mount(string|Variant $variant, string|ButtonType $type = ButtonType::BUTTON): void
     {
-        if (\is_string($variant) && str_contains($variant, 'outline')) {
-            $this->isOutline = true;
-            $variant = substr($variant, 8);
+        if (\is_string($variant)) {
+            if (str_contains($variant, 'outline')) {
+                $this->isOutline = true;
+                $variant = substr($variant, 8);
+            }
+
+            if (str_contains($variant, 'close')) {
+                $this->isClose = true;
+                $variant = Variant::PRIMARY;
+            }
         }
 
         try {
@@ -48,6 +56,10 @@ final class Button implements VariantInterface
 
     public function getDefaultCssClass(): string
     {
+        if ($this->isClose) {
+            return 'btn-close';
+        }
+
         if ($this->isOutline) {
             return sprintf('btn btn-outline-%s', $this->variant->value);
         }

--- a/templates/components/Alert.html.twig
+++ b/templates/components/Alert.html.twig
@@ -14,6 +14,6 @@
     </div>
 
     {%- if this.dismissible -%}
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ 'codeschubser.action.close.label'|trans }}"></button>
+        <twig:Button variant="close" data-bs-dismiss="alert" aria-label="{{ 'codeschubser.action.close.label'|trans }}" />
     {%- endif -%}
 </div>

--- a/tests/Integration/Twig/Components/AlertTest.php
+++ b/tests/Integration/Twig/Components/AlertTest.php
@@ -8,11 +8,13 @@ use Codeschubser\Bundle\TwigComponents\CodeschubserTwigComponentsBundle;
 use Codeschubser\Bundle\TwigComponents\DependencyInjection\CodeschubserTwigComponentsExtension;
 use Codeschubser\Bundle\TwigComponents\Tests\Common\AbstractComponentsTestCase;
 use Codeschubser\Bundle\TwigComponents\Twig\Component\Alert;
+use Codeschubser\Bundle\TwigComponents\Twig\Component\Button;
 use Codeschubser\Bundle\TwigComponents\Twig\Component\Option\Variant;
 use Codeschubser\Bundle\TwigComponents\Twig\Component\Option\VariantInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(Alert::class)]
+#[CoversClass(Button::class)]
 #[CoversClass(Variant::class)]
 #[CoversClass(CodeschubserTwigComponentsBundle::class)]
 #[CoversClass(CodeschubserTwigComponentsExtension::class)]


### PR DESCRIPTION
- Added `close` variant für buttons (fixes #20)
- Use close button variant for `dismissible` alerts (fixes #15)
- Print code coverage as text by `composer test:coverage:generate`